### PR TITLE
Fix bug: Pressing tab on suggestions does not focus and close the suggestion container

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -45,7 +45,7 @@
 }
 #___suggestion-container___ .___first-dummy-suggestion___,
 #___suggestion-container___ .___last-dummy-suggestion___ {
-    display: none;
+	opacity: 0;
 }
 .editor {
   counter-reset: line;


### PR DESCRIPTION
Turn opacity to 0 instead of display none as display none disables pointer events on an element